### PR TITLE
Adding CodeReview support

### DIFF
--- a/TfsNotificationRelay/Configuration/EventRuleElement.cs
+++ b/TfsNotificationRelay/Configuration/EventRuleElement.cs
@@ -48,6 +48,12 @@ namespace DevCore.TfsNotificationRelay.Configuration
             get { return (string)this["teamProject"]; }
         }
 
+        [ConfigurationProperty("teamAreaPath")]
+        public string TeamAreaPath
+        {
+            get { return (string)this["teamAreaPath"]; }
+        }
+
         [ConfigurationProperty("gitRepository")]
         public string GitRepository
         {

--- a/TfsNotificationRelay/EventHandlers/WorkItemChangedHandler.cs
+++ b/TfsNotificationRelay/EventHandlers/WorkItemChangedHandler.cs
@@ -43,6 +43,7 @@ namespace DevCore.TfsNotificationRelay.EventHandlers
                 WiId = ev.CoreFields.IntegerFields.Single(f => f.ReferenceName == "System.Id").NewValue,
                 WiTitle = ev.WorkItemTitle,
                 ProjectName = ev.PortfolioProject,
+                AreaPath = ev.AreaPath,
                 IsStateChanged = ev.ChangedFields.StringFields.Any(f => f.ReferenceName == "System.State"),
                 IsAssignmentChanged = ev.ChangedFields.StringFields.Any(f => f.ReferenceName == "System.AssignedTo"),
                 IsCodeReviewRequest = ev.CoreFields.StringFields.Single(f => f.ReferenceName == "System.WorkItemType").NewValue.Contains("Code Review Request"),

--- a/TfsNotificationRelay/EventHandlers/WorkItemChangedHandler.cs
+++ b/TfsNotificationRelay/EventHandlers/WorkItemChangedHandler.cs
@@ -45,6 +45,7 @@ namespace DevCore.TfsNotificationRelay.EventHandlers
                 ProjectName = ev.PortfolioProject,
                 IsStateChanged = ev.ChangedFields.StringFields.Any(f => f.ReferenceName == "System.State"),
                 IsAssignmentChanged = ev.ChangedFields.StringFields.Any(f => f.ReferenceName == "System.AssignedTo"),
+                IsCodeReviewRequest = ev.CoreFields.StringFields.Single(f => f.ReferenceName == "System.WorkItemType").NewValue.Contains("Code Review Request"),
                 State = ev.CoreFields.StringFields.Single(f => f.ReferenceName == "System.State").NewValue,
                 AssignedTo = ev.CoreFields.StringFields.Single(f => f.ReferenceName == "System.AssignedTo").NewValue
             };

--- a/TfsNotificationRelay/Notifications/WorkItemChangedNotification.cs
+++ b/TfsNotificationRelay/Notifications/WorkItemChangedNotification.cs
@@ -34,6 +34,7 @@ namespace DevCore.TfsNotificationRelay.Notifications
         public string ProjectName { get; set; }
         public bool IsStateChanged { get; set; }
         public bool IsAssignmentChanged { get; set; }
+        public bool IsCodeReviewRequest { get; set; }
         public string AssignedTo { get; set; }
         public string State { get; set; }
 
@@ -77,7 +78,8 @@ namespace DevCore.TfsNotificationRelay.Notifications
         {
             var rule = eventRules.FirstOrDefault(r =>
                 (r.Events.HasFlag(TfsEvents.WorkItemStateChange) && IsStateChanged
-                || r.Events.HasFlag(TfsEvents.WorkItemAssignmentChange) && IsAssignmentChanged)
+                || r.Events.HasFlag(TfsEvents.WorkItemAssignmentChange) && IsAssignmentChanged
+                || r.Events.HasFlag(TfsEvents.WorkItemCodeReviewRequested) && IsCodeReviewRequest)
                 && collection.IsMatchOrNoPattern(r.TeamProjectCollection)
                 && ProjectName.IsMatchOrNoPattern(r.TeamProject));
 

--- a/TfsNotificationRelay/Notifications/WorkItemChangedNotification.cs
+++ b/TfsNotificationRelay/Notifications/WorkItemChangedNotification.cs
@@ -32,6 +32,7 @@ namespace DevCore.TfsNotificationRelay.Notifications
         public int WiId { get; set; }
         public string WiTitle { get; set; }
         public string ProjectName { get; set; }
+        public string AreaPath { get; set; }
         public bool IsStateChanged { get; set; }
         public bool IsAssignmentChanged { get; set; }
         public bool IsCodeReviewRequest { get; set; }
@@ -81,7 +82,8 @@ namespace DevCore.TfsNotificationRelay.Notifications
                 || r.Events.HasFlag(TfsEvents.WorkItemAssignmentChange) && IsAssignmentChanged
                 || r.Events.HasFlag(TfsEvents.WorkItemCodeReviewRequested) && IsCodeReviewRequest)
                 && collection.IsMatchOrNoPattern(r.TeamProjectCollection)
-                && ProjectName.IsMatchOrNoPattern(r.TeamProject));
+                && ProjectName.IsMatchOrNoPattern(r.TeamProject)
+                && AreaPath.IsMatchOrNoPattern(r.TeamAreaPath));
 
             if (rule != null) return rule.Notify;
 

--- a/TfsNotificationRelay/TfsEvents.cs
+++ b/TfsNotificationRelay/TfsEvents.cs
@@ -35,6 +35,7 @@ namespace DevCore.TfsNotificationRelay
         PullRequestStatusUpdate = 512,
         PullRequestReviewerVote = 1024,
         BuildQualityChanged = 2048,
+        WorkItemCodeReviewRequested = 4096,
 
         All = 0xFFFFFFFF
     }

--- a/TfsNotificationRelay/TfsNotificationRelay.xsd
+++ b/TfsNotificationRelay/TfsNotificationRelay.xsd
@@ -45,6 +45,7 @@
                               <xs:attribute name="notify" type="xs:boolean" use="required" />
                               <xs:attribute name="teamProjectCollection" type="xs:string" />
                               <xs:attribute name="teamProject" type="xs:string" />
+                              <xs:attribute name="teamAreaPath" type="xs:string" />
                               <xs:attribute name="gitRepository" type="xs:string" />
                               <xs:attribute name="buildDefinition" type="xs:string" />
                             </xs:complexType>

--- a/TfsNotificationRelay/app.config
+++ b/TfsNotificationRelay/app.config
@@ -45,7 +45,7 @@
             
             The teamProjectCollection, teamProject, gitRepository and buildDefinition attributes take regex patterns. 
             -->
-          <rule events="All" notify="true" teamProjectCollection=".*" teamProject=".*" gitRepository=".*" buildDefinition=".*" />
+          <rule events="All" notify="true" teamProjectCollection=".*" teamProject=".*" teamAreaPath=".*" gitRepository=".*" buildDefinition=".*" />
         </eventRules>
       </bot>
       <!--


### PR DESCRIPTION
Added a third TfsEvent called WorkItemCodeReviewRequested (the other two being WorkItemStateChange and WorkItemAssignmentChange) for the TFS WorkItemChanged event.  This event looks for the phrase "Code Review Request" in a WorkItemChangeEvent to determine if this work item is a Code Review work item.

Also added a config for teamAreaPath to be able to filter by AreaPath.  Could be implemented in other Notifications as well. I can easily split this out as a separate PR if you'd like.