### PR TITLE
Allow pull request comment notification to include Slack user id

### DIFF
--- a/TfsNotificationRelay/Notifications/PullRequestCommentNotification.cs
+++ b/TfsNotificationRelay/Notifications/PullRequestCommentNotification.cs
@@ -12,6 +12,7 @@
  */
 
 using DevCore.TfsNotificationRelay.Configuration;
+using Microsoft.TeamFoundation.Server.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,9 +37,11 @@ namespace DevCore.TfsNotificationRelay.Notifications
                 PrTitle = transform(PrTitle),
                 UserName = transform(UserName),
                 SourceBranchName = transform(SourceBranch.Name),
-                TargetBranchName = transform(TargetBranch.Name)
+                TargetBranchName = transform(TargetBranch.Name),
+                CreatorUserId = bot.GetMappedUser(CreatorUserName),
+                UserId = bot.GetMappedUser(UniqueName)
             };
-
+            
             return new[] { bot.Text.PullRequestCommentFormat.FormatWith(formatter), Comment };
         }
 

--- a/TfsNotificationRelay/app.config
+++ b/TfsNotificationRelay/app.config
@@ -23,7 +23,7 @@
       <!--
         Multiple bots can be added here, just make sure they have a unique id.
         -->
-      <bot id="slack" type="DevCore.TfsNotificationRelay.Slack.SlackNotifier, DevCore.TfsNotificationRelay.Slack" textId="slacktext">
+      <bot id="slack" type="DevCore.TfsNotificationRelay.Slack.SlackNotifier, DevCore.TfsNotificationRelay.Slack" textId="slacktext" userMapId="slackusers">
         <botSettings>
           <add name="webhookUrl" value="" />
           <add name="channels" value="#general" /> <!-- one or many comma-separated channels -->
@@ -164,7 +164,7 @@
         assignedTo="Assigned To"
         repositoryCreatedFormat="{userName} created repository &lt;{repoUri}|{projectName}/{repoName}&gt;"
         commitCommentFormat="{userName} commented on &lt;{commitUri}|{commitId}&gt; in &lt;{repoUri}|{projectName}/{repoName}&gt;"
-        pullRequestCommentFormat="{userName} commented on &lt;{prUrl}|pull request #{prId}&gt; in &lt;{repoUri}|{projectName}/{repoName}&gt; - {prTitle}"
+        pullRequestCommentFormat="{userName} commented on &lt;{prUrl}|pull request #{prId}&gt; in &lt;{repoUri}|{projectName}/{repoName}&gt; - {prTitle} by &lt;@{CreatorUserId}&gt;"
         changesetCommentFormat="{userName} commented on &lt;{changesetUrl}|Changeset {changesetId}&gt; in &lt;{projectUrl}|{projectName}&gt;"
           />
       <text id="htmltext"


### PR DESCRIPTION
We're setting up TFS/Slack integration and this is a little something I've added. I'll probably add something similar to other pull request notifications eventually.