### PR TITLE
While finding a TFS UserName via GetMappedUser, use a case insensitive search

### DIFF
--- a/TfsNotificationRelay/Configuration/BotElement.cs
+++ b/TfsNotificationRelay/Configuration/BotElement.cs
@@ -42,7 +42,7 @@ namespace DevCore.TfsNotificationRelay.Configuration
 
         public string GetMappedUser(string tfsUserName)
         {
-            var userMapping = UserMap.FirstOrDefault(u => u.TfsUser == tfsUserName);
+            var userMapping = UserMap.FirstOrDefault(u => u.TfsUser.Equals(tfsUserName, StringComparison.OrdinalIgnoreCase));
             return userMapping?.MappedUser;
         }
 


### PR DESCRIPTION
A small change, but may be helpful to get people up and running more quickly. If this isn't an appropriate change, then a comment to the app.config file stating it is case sensitive would be helpful too.